### PR TITLE
removed Gem commands from the bin/dm file.

### DIFF
--- a/bin/dm
+++ b/bin/dm
@@ -3,10 +3,8 @@
 require 'optparse'
 require 'rubygems'
 
-gem 'dm-core', '1.0.0'
 require 'dm-core'
 
-gem 'dm-cli', '1.0.0'
 require 'dm-cli'
 
 DataMapper::CLI::BinDir = File.dirname(__FILE__)


### PR DESCRIPTION
Gem commands to import dm-core and dm-cli are in the gemspec.

They shouldn't live in the bin/dm file.

(They most certainly shouldn't have the 1.0 versions specified here).
